### PR TITLE
Fix cargo bays

### DIFF
--- a/Extras/ModCompat/TaurusHCVCommunityTechTree.cfg
+++ b/Extras/ModCompat/TaurusHCVCommunityTechTree.cfg
@@ -1,0 +1,14 @@
+// Taurus HCV part rearranging for Community Tech Tree
+// Trimmed from DaPatman's original by Kerbas_ad_astra
+
+// RS-2 "Tiny" X-tra Large Atomic Motor
+@PART[taurusNuclearEngine]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advNuclearPropulsion
+}
+
+// Taurus HCV
+@PART[TaurusHCV]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = heavyCommandModules
+}

--- a/Patches/Command.cfg
+++ b/Patches/Command.cfg
@@ -13,7 +13,7 @@
   //node_stack_top = 0.0, 1.25, 0.0, 0.0, 1.0, 0.0, 1
   //node_stack_bottom = 0.0, -1.25, 0.0, 0.0, -1.0, 0.0, 3
 
-  //TechRequired = metaMaterials
+  @TechRequired = commandModules
   //entryCost = 18500
   //cost = 7000
   //category = Pods

--- a/Patches/Coupling.cfg
+++ b/Patches/Coupling.cfg
@@ -13,7 +13,7 @@
   //fx_gasBurst_white = 0.0, 0.0650517, 0.0, 0.0, 1.0, 0.0, decouple
   //sound_vent_large = decouple
 
-  //TechRequired = veryHeavyRocketry
+  @TechRequired = largeVolumeContainment
   @entryCost = 14500 // 1450
   @cost = 1450 // 800
   @category = Coupling // Structural

--- a/Patches/Crew.cfg
+++ b/Patches/Crew.cfg
@@ -10,7 +10,7 @@
   //node_stack_bottom = 0.0, -1, 0.0, 0.0, -1, 0.0, 3
   //node_attach = 0.0, 0.0, -1.89, 0.0, 0.0, 1.0
 
-  //TechRequired = metaMaterials
+  @TechRequired = advExploration
   @entryCost = 24800 // 12500
   @cost = 8000 // 5000
   //category = Utility

--- a/Patches/Electric.cfg
+++ b/Patches/Electric.cfg
@@ -7,7 +7,7 @@
   //node_stack_top = 0.0, 0.25, 0.0, 0.0, 1, 0.0, 3
   //node_stack_bottom = 0.0, -0.25, 0.0, 0.0, -1, 0.0, 3
 
-  //TechRequired = veryHeavyRocketry
+  @TechRequired = experimentalElectrics
   //entryCost = 20000
   //cost = 12000
   //category = Control

--- a/Patches/Science.cfg
+++ b/Patches/Science.cfg
@@ -104,9 +104,11 @@
 
   @MODULE[ModuleCargoBay]
   {
-  	//DeployModuleIndex = 3
-  	//closedPosition = 0
-  	@lookupRadius = 2.7 // 3
+  	lookupCenter = 1.5,0,0
+  }
+  +MODULE[ModuleCargoBay]
+  {
+  	@lookupCenter = -1.5,0,0
   }
 
 

--- a/Patches/Tanks.cfg
+++ b/Patches/Tanks.cfg
@@ -11,7 +11,7 @@
   //node_stack_bottom = 0.0, -0.5, 0.0, 0.0, -1, 0.0, 3
   %node_attach = 0.0, 0.0, -1.89, 0.0, 0.0, 1.0
 
-  //TechRequired = veryHeavyRocketry
+  @TechRequired = largeVolumeContainment
   @entryCost = 9400 // 9999
   //cost = 1625
   @category = FuelTank // Propulsion


### PR DESCRIPTION
The lookupCenter of a cargo bay needs to be in the middle of the bay itself (i.e. not 'buried' inside the part), and since this part has two bays, it needs to ModuleCargoBays with different lookupCenters.

How to test cargo bays: put a deployable solar panel inside, and (e.g. with Part Commander) try to deploy the panels while the bay is shut.  If they deploy, the bay isn't shielding them.